### PR TITLE
fix paths in MovieDetailsModule package file

### DIFF
--- a/MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule/Package.swift
+++ b/MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule/Package.swift
@@ -18,9 +18,9 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
-        .package(path: "../../MANetwork"),
-        .package(path: "../../MoviesLookups"),
-        .package(path: "../../Commons")
+        .package(path: "../../../MANetwork"),
+        .package(path: "../../../MoviesLookups"),
+        .package(path: "../../../Commons")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Now your MovieDetailsModule package can works fine
and it would look like this when try to open or build it

Note: these warning are from duplicated dependencies 


<img width="1019" alt="Screenshot 2025-04-23 at 2 43 37 AM" src="https://github.com/user-attachments/assets/7d1ede2a-f0ee-4705-a14e-d385ba98ba63" />
