### PR TITLE
fix paths in MoviesModule package

### DIFF
--- a/MoviesList-MVVM-SwiftUI/Modules/MoviesModule/Package.swift
+++ b/MoviesList-MVVM-SwiftUI/Modules/MoviesModule/Package.swift
@@ -18,10 +18,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
-        .package(path: "../../MANetwork"),
-        .package(path: "../../MoviesLookups"),
-        .package(path: "../../Commons"),
-        .package(path: "../../DatabaseKit")
+        .package(path: "../../../MANetwork"),
+        .package(path: "../../../MoviesLookups"),
+        .package(path: "../../../Commons"),
+        .package(path: "../../../DatabaseKit")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Paths are fixed in `Package.swift` file
Package is standalone building now

<img width="1129" alt="Screenshot 2025-04-23 at 2 58 25 AM" src="https://github.com/user-attachments/assets/773758c2-6002-43ee-b21b-b0b0747aded8" />

Warning from duplicated dependencies
<img width="301" alt="Screenshot 2025-04-23 at 2 58 41 AM" src="https://github.com/user-attachments/assets/77b2fe1a-0cbf-4c8f-9498-55f3f549c209" />
