### PR TITLE
fix: add packages to spm

### DIFF
--- a/Commons/Package.swift
+++ b/Commons/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(path: "MANetwork")
+        .package(path: "../MANetwork")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/MoviesList-MVVM-SwiftUI.xcodeproj/project.pbxproj
+++ b/MoviesList-MVVM-SwiftUI.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 			children = (
 				A28E378E2C6016F1001521F4 /* MoviesList-MVVM-SwiftUI */,
 				A28E378D2C6016F1001521F4 /* Products */,
-				A28E38222C6176F3001521F4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -103,13 +102,6 @@
 				A28E37F92C6060ED001521F4 /* MoviesCoordinatorView.swift */,
 			);
 			path = Coordinator;
-			sourceTree = "<group>";
-		};
-		A28E38222C6176F3001521F4 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/MoviesList-MVVM-SwiftUI.xcodeproj/project.pbxproj
+++ b/MoviesList-MVVM-SwiftUI.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		96D886322DB99ED600075786 /* MoviesModule in Frameworks */ = {isa = PBXBuildFile; productRef = 96D886312DB99ED600075786 /* MoviesModule */; };
+		96D886352DB99EE900075786 /* MovieDetailsModule in Frameworks */ = {isa = PBXBuildFile; productRef = 96D886342DB99EE900075786 /* MovieDetailsModule */; };
 		A21B59B92C61A2890032A053 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = A21B59B82C61A2890032A053 /* Kingfisher */; };
 		A21B59BB2C61A2A10032A053 /* MoviesLookups in Frameworks */ = {isa = PBXBuildFile; productRef = A21B59BA2C61A2A10032A053 /* MoviesLookups */; };
 		A21B59BD2C61A2A50032A053 /* MoviesModule in Frameworks */ = {isa = PBXBuildFile; productRef = A21B59BC2C61A2A50032A053 /* MoviesModule */; };
@@ -22,18 +24,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		A21B59B32C619ED30032A053 /* Commons */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Commons; sourceTree = "<group>"; };
-		A21B59B42C61A0360032A053 /* MANetwork */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MANetwork; sourceTree = "<group>"; };
-		A21B59B52C61A14C0032A053 /* MoviesLookups */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MoviesLookups; sourceTree = "<group>"; };
-		A21B59B62C61A2220032A053 /* MoviesModule */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MoviesModule; sourceTree = "<group>"; };
-		A21B59C32C61A4F70032A053 /* MovieDetailsModule */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = MovieDetailsModule; sourceTree = "<group>"; };
 		A28E378C2C6016F1001521F4 /* MoviesList-MVVM-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "MoviesList-MVVM-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A28E378F2C6016F1001521F4 /* MoviesList_MVVM_SwiftUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesList_MVVM_SwiftUIApp.swift; sourceTree = "<group>"; };
 		A28E37932C6016F2001521F4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A28E37962C6016F2001521F4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		A28E37F72C605D9C001521F4 /* MoviesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesCoordinator.swift; sourceTree = "<group>"; };
 		A28E37F92C6060ED001521F4 /* MoviesCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesCoordinatorView.swift; sourceTree = "<group>"; };
-		A2B46F412D6BEACC00C79FC4 /* DatabaseKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = DatabaseKit; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -44,8 +40,10 @@
 				A21B59C52C61A6160032A053 /* MovieDetailsModule in Frameworks */,
 				A21B59B92C61A2890032A053 /* Kingfisher in Frameworks */,
 				A21B59C12C61A3470032A053 /* MANetwork in Frameworks */,
+				96D886352DB99EE900075786 /* MovieDetailsModule in Frameworks */,
 				A2B46F442D6BEB8200C79FC4 /* DatabaseKit in Frameworks */,
 				A21B59BD2C61A2A50032A053 /* MoviesModule in Frameworks */,
+				96D886322DB99ED600075786 /* MoviesModule in Frameworks */,
 				A21B59BB2C61A2A10032A053 /* MoviesLookups in Frameworks */,
 				A21B59BF2C61A3420032A053 /* Commons in Frameworks */,
 			);
@@ -57,10 +55,6 @@
 		A28E37832C6016F1001521F4 = {
 			isa = PBXGroup;
 			children = (
-				A2B46F412D6BEACC00C79FC4 /* DatabaseKit */,
-				A21B59B42C61A0360032A053 /* MANetwork */,
-				A21B59B52C61A14C0032A053 /* MoviesLookups */,
-				A21B59B32C619ED30032A053 /* Commons */,
 				A28E378E2C6016F1001521F4 /* MoviesList-MVVM-SwiftUI */,
 				A28E378D2C6016F1001521F4 /* Products */,
 				A28E38222C6176F3001521F4 /* Frameworks */,
@@ -98,8 +92,6 @@
 			isa = PBXGroup;
 			children = (
 				A28E37F62C605D82001521F4 /* Coordinator */,
-				A21B59B62C61A2220032A053 /* MoviesModule */,
-				A21B59C32C61A4F70032A053 /* MovieDetailsModule */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -144,6 +136,8 @@
 				A21B59C02C61A3470032A053 /* MANetwork */,
 				A21B59C42C61A6160032A053 /* MovieDetailsModule */,
 				A2B46F432D6BEB8200C79FC4 /* DatabaseKit */,
+				96D886312DB99ED600075786 /* MoviesModule */,
+				96D886342DB99EE900075786 /* MovieDetailsModule */,
 			);
 			productName = "MoviesList-MVVM-SwiftUI";
 			productReference = A28E378C2C6016F1001521F4 /* MoviesList-MVVM-SwiftUI.app */;
@@ -176,6 +170,8 @@
 			packageReferences = (
 				A21B59B72C61A2890032A053 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				A2B46F422D6BEB8200C79FC4 /* XCLocalSwiftPackageReference "DatabaseKit" */,
+				96D886302DB99ED500075786 /* XCLocalSwiftPackageReference "MoviesList-MVVM-SwiftUI/Modules/MoviesModule" */,
+				96D886332DB99EE900075786 /* XCLocalSwiftPackageReference "MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule" */,
 			);
 			productRefGroup = A28E378D2C6016F1001521F4 /* Products */;
 			projectDirPath = "";
@@ -413,6 +409,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		96D886302DB99ED500075786 /* XCLocalSwiftPackageReference "MoviesList-MVVM-SwiftUI/Modules/MoviesModule" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "MoviesList-MVVM-SwiftUI/Modules/MoviesModule";
+		};
+		96D886332DB99EE900075786 /* XCLocalSwiftPackageReference "MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule";
+		};
 		A2B46F422D6BEB8200C79FC4 /* XCLocalSwiftPackageReference "DatabaseKit" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = DatabaseKit;
@@ -431,6 +435,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		96D886312DB99ED600075786 /* MoviesModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MoviesModule;
+		};
+		96D886342DB99EE900075786 /* MovieDetailsModule */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MovieDetailsModule;
+		};
 		A21B59B82C61A2890032A053 /* Kingfisher */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = A21B59B72C61A2890032A053 /* XCRemoteSwiftPackageReference "Kingfisher" */;

--- a/MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule/Package.swift
+++ b/MoviesList-MVVM-SwiftUI/Modules/MovieDetailsModule/Package.swift
@@ -18,9 +18,9 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
-        .package(path: "../../MANetwork"),
-        .package(path: "../../MoviesLookups"),
-        .package(path: "../../Commons")
+        .package(path: "../../../MANetwork"),
+        .package(path: "../../../MoviesLookups"),
+        .package(path: "../../../Commons")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/MoviesList-MVVM-SwiftUI/Modules/MoviesModule/Package.swift
+++ b/MoviesList-MVVM-SwiftUI/Modules/MoviesModule/Package.swift
@@ -18,10 +18,10 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.12.0"),
-        .package(path: "../../MANetwork"),
-        .package(path: "../../MoviesLookups"),
-        .package(path: "../../Commons"),
-        .package(path: "../../DatabaseKit")
+        .package(path: "../../../MANetwork"),
+        .package(path: "../../../MoviesLookups"),
+        .package(path: "../../../Commons"),
+        .package(path: "../../../DatabaseKit")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/MoviesLookups/Package.swift
+++ b/MoviesLookups/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(path: "MANetwork")
+        .package(path: "../MANetwork")
         ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## Overview

This PR introduces several enhancements and fixes, including improvements derived from [PR#6](https://github.com/AhmedMenaim/Modular-MoviesList-SwiftUI-MVVM/pull/6) and [PR#5](https://github.com/AhmedMenaim/Modular-MoviesList-SwiftUI-MVVM/pull/5) .

### Key Changes:
1. **Migration to Swift Package Manager (SPM):**
   - Refactored the project structure to adopt Swift Package Manager for managing feature modules.
   - Simplified dependency resolution by letting Xcode and SPM handle both primary dependencies and sub-dependencies automatically.

2. **Improved Dependency Management:**
   - Previously, the project lacked proper handling of feature module dependencies and their sub-dependencies.
   - Now, all dependencies (including transitive ones) are managed and resolved by Xcode’s SPM.
   - For instance, adding a feature module like `MovieDetailsModule` to the project dependencies will automatically resolve its sub-dependencies and manage relationships with other modules.

3. **Cleaner Project Structure:**
   - The migration to SPM results in a more modular and maintainable codebase, with better organization and separation of concerns.

4. **App-Specific Dependencies:**
   - The app project now only includes the feature modules in its package dependencies. This ensures a focused and minimal dependency setup while leveraging SPM to manage sub-dependencies transparently.

### Benefits:
- A cleaner, more maintainable project structure.
- Seamless dependency resolution and management.
- Reduced manual effort in handling complex module relationships.
- Improved scalability and maintainability for future development efforts.

### Screenshots

**Before:**

<img width="857" alt="Screenshot 2025-04-24 at 12 24 08 AM" src="https://github.com/user-attachments/assets/7311e1d0-acf7-4338-9675-2351927e625c" />
<img width="1135" alt="Screenshot 2025-04-24 at 12 42 33 AM" src="https://github.com/user-attachments/assets/fecc23ea-787c-4388-a4e8-b93bedcddc4d" />


**After:**
<img width="1133" alt="Screenshot 2025-04-24 at 12 44 31 AM" src="https://github.com/user-attachments/assets/65c143ca-8119-4615-b3d4-8054582eb20e" />

The images above illustrate how the project structure and dependency management have improved after migrating to Swift Package Manager. Notably, the app project now only includes the feature modules in its package dependencies, with sub-dependencies being resolved automatically by Xcode and SPM.

### Additional Notes
- The changes introduced in this PR ensure that adding a single feature module automatically resolves its dependencies, reducing the overhead of manually managing sub-dependencies.
- Please review the changes thoroughly to ensure compatibility with existing workflows.